### PR TITLE
Protected in repository classes

### DIFF
--- a/resources/templates/repository.ftl
+++ b/resources/templates/repository.ftl
@@ -7,8 +7,13 @@ import java.util.UUID;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+// <protected:imports>
+// </protected:imports>
+
 import ${entityPackage}.${clazz.name};
 
 @Repository
 public interface ${clazz.name}Repository extends JpaRepository<${clazz.name}, ${idType}> {
+	// <protected:methods>
+	// </protected:methods>
 }

--- a/resources/templates/repository.ftl
+++ b/resources/templates/repository.ftl
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 // <protected:imports>
+
 // </protected:imports>
 
 import ${entityPackage}.${clazz.name};
@@ -15,5 +16,6 @@ import ${entityPackage}.${clazz.name};
 @Repository
 public interface ${clazz.name}Repository extends JpaRepository<${clazz.name}, ${idType}> {
 	// <protected:methods>
+
 	// </protected:methods>
 }

--- a/src/myplugin/generator/RepositoryGenerator.java
+++ b/src/myplugin/generator/RepositoryGenerator.java
@@ -1,9 +1,15 @@
 package myplugin.generator;
 
+import java.io.File;
 import java.io.IOException;
-import java.io.Writer;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import myplugin.MyPlugin;
 import myplugin.generator.fmmodel.FMClass;
@@ -11,6 +17,11 @@ import myplugin.generator.fmmodel.FMModel;
 import myplugin.generator.options.GeneratorOptions;
 
 public class RepositoryGenerator extends BasicGenerator {
+
+    private static final String IMPORTS_START = "// <protected:imports>";
+    private static final String IMPORTS_END = "// </protected:imports>";
+    private static final String METHODS_START = "// <protected:methods>";
+    private static final String METHODS_END = "// </protected:methods>";
 
     private final TypeUtil typeUtil = new TypeUtil();
 
@@ -23,8 +34,10 @@ public class RepositoryGenerator extends BasicGenerator {
         super.generate();
 
         for (FMClass clazz : FMModel.getInstance().getClasses()) {
-            Writer out = getWriter(clazz.getName() + "Repository", generatorOptions.getFilePackage());
-            if (out == null) continue;
+            Path outputPath = resolveOutputPath(clazz.getName() + "Repository", generatorOptions.getFilePackage());
+            if (!generatorOptions.getOverwrite() && Files.exists(outputPath)) {
+                continue;
+            }
 
             String idType = clazz.resolveIdType(generatorOptions);
 
@@ -36,12 +49,80 @@ public class RepositoryGenerator extends BasicGenerator {
             model.put("entityPackage", MyPlugin.ENTITY_OPTIONS.getFilePackage());
 
             try {
-                getTemplate().process(model, out);
+                String generatedContent = renderTemplate(model);
+                String finalContent = generatedContent;
+
+                if (Files.exists(outputPath)) {
+                    String existingContent = new String(Files.readAllBytes(outputPath), StandardCharsets.UTF_8);
+                    try {
+                        String importsBlock = extractProtectedContent(existingContent, IMPORTS_START, IMPORTS_END);
+                        String methodsBlock = extractProtectedContent(existingContent, METHODS_START, METHODS_END);
+                        finalContent = replaceProtectedContent(finalContent, IMPORTS_START, IMPORTS_END, importsBlock);
+                        finalContent = replaceProtectedContent(finalContent, METHODS_START, METHODS_END, methodsBlock);
+                    } catch (IllegalStateException e) {
+                        System.err.println("Skipping overwrite for malformed protected areas in: " + outputPath);
+                        continue;
+                    }
+                }
+
+                Path parent = outputPath.getParent();
+                if (parent != null && !Files.exists(parent)) {
+                    Files.createDirectories(parent);
+                }
+                Files.write(outputPath, finalContent.getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new IOException("Template processing failed for repository: " + clazz.getName(), e);
-            } finally {
-                out.close();
             }
         }
+    }
+
+    private String renderTemplate(Map<String, Object> model) throws Exception {
+        StringWriter out = new StringWriter();
+        getTemplate().process(model, out);
+        return out.toString();
+    }
+
+    private Path resolveOutputPath(String fileNamePart, String packageName) {
+        String filePackage = generatorOptions.getFilePackage();
+        if (!Objects.equals(packageName, filePackage)) {
+            filePackage = packageName.replace(".", File.separator);
+        }
+
+        String fullPath = generatorOptions.getOutputPath()
+                + File.separator
+                + (filePackage.isEmpty() ? "" : packageToPath(filePackage)
+                        + File.separator)
+                + generatorOptions.getOutputFileName().replace("{0}", fileNamePart);
+
+        return Paths.get(fullPath);
+    }
+
+    private String extractProtectedContent(String source, String startMarker, String endMarker) {
+        int start = source.indexOf(startMarker);
+        int end = source.indexOf(endMarker);
+
+        if (start < 0 && end < 0) {
+            return "";
+        }
+        if (start < 0 || end < 0 || end < start) {
+            throw new IllegalStateException("Malformed protected block");
+        }
+
+        int contentStart = start + startMarker.length();
+        return source.substring(contentStart, end);
+    }
+
+    private String replaceProtectedContent(String target, String startMarker, String endMarker, String preservedContent) {
+        int start = target.indexOf(startMarker);
+        int end = target.indexOf(endMarker);
+
+        if (start < 0 || end < 0 || end < start) {
+            throw new IllegalStateException("Protected markers not found in template output");
+        }
+
+        int contentStart = start + startMarker.length();
+        return target.substring(0, contentStart)
+                + preservedContent
+                + target.substring(end);
     }
 }

--- a/src/myplugin/generator/RepositoryGenerator.java
+++ b/src/myplugin/generator/RepositoryGenerator.java
@@ -123,8 +123,14 @@ public class RepositoryGenerator extends BasicGenerator {
         }
 
         int contentStart = start + startMarker.length();
+        String contentToInsert = preservedContent;
+        if (contentToInsert == null || contentToInsert.trim().isEmpty()) {
+            // Keep at least one empty line between markers for stable regeneration.
+            contentToInsert = System.lineSeparator() + System.lineSeparator();
+        }
+
         return target.substring(0, contentStart)
-                + preservedContent
-                + target.substring(end);
+            + contentToInsert
+            + target.substring(end);
     }
 }


### PR DESCRIPTION
- When generating repository classes generators generate `// <protected:imports>` and  `// <protected:methods>` marker comments
- Repository generator now preserves code between `// <protected:imports>` and `// </protected:imports>` markers
- Also preserves custom methods between `// <protected:methods>` and `// </protected:methods>` markers
- Should close #7 
