### PR TITLE
Feat/new methods

### DIFF
--- a/resources/templates/entity.ftl
+++ b/resources/templates/entity.ftl
@@ -16,10 +16,14 @@ import ${i};
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Entity
-@Table(name = "${nameUtil.toSnakeCase(clazz.name)}")
+<#if clazz.embeddable>
+  @Embeddable
+<#else>
+  @Entity
+  @Table(name = "${nameUtil.toSnakeCase(clazz.name)}")
+</#if>
 public class ${clazz.name} {
-<#if !hasId>
+<#if !hasId && !clazz.embeddable>
   <#if idStrategy?string == "LONG_IDENTITY">
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,7 +45,11 @@ public class ${clazz.name} {
     @GeneratedValue
     </#if>
   </#if>
-  <#if p.relation>
+
+  <#if p.embedded>
+    @Embedded
+    private ${p.targetClass} ${p.name};
+  <#elseif p.relation>
     <#if p.relationKind.name() == "MANY_TO_ONE">
     <#if p.nullable?? && !p.nullable>
     @NotNull
@@ -84,7 +92,7 @@ public class ${clazz.name} {
     )
     private Set<${p.targetClass}> ${p.name} = new HashSet<${p.targetClass}>();
     </#if>
-  </#if>
+    </#if>
   <#else>
     <#if p.nullable?? && !p.nullable>
     @NotNull

--- a/resources/templates/repository.ftl
+++ b/resources/templates/repository.ftl
@@ -4,6 +4,10 @@ package ${packageName};
 import java.util.UUID;
 </#if>
 
+import java.util.Optional;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +15,22 @@ import ${entityPackage}.${clazz.name};
 
 @Repository
 public interface ${clazz.name}Repository extends JpaRepository<${clazz.name}, ${idType}> {
+
+<#list clazz.properties as p>
+<#if p.searchable && !p.relation && !p.embedded>
+<#if p.unique>
+    Optional<${clazz.name}> findBy${p.name?cap_first}(${typeUtil.toJava(p.type)} ${p.name});
+<#else>
+    List<${clazz.name}> findBy${p.name?cap_first}(${typeUtil.toJava(p.type)} ${p.name});
+</#if>
+</#if>
+
+<#if p.rangeQuery && !p.relation && !p.embedded>
+    List<${clazz.name}> findBy${p.name?cap_first}Between(${typeUtil.toJava(p.type)} start, ${typeUtil.toJava(p.type)} end);
+</#if>
+</#list>
+
+<#if clazz.pagination>
+    Page<${clazz.name}> findAll(Pageable pageable);
+</#if>
 }

--- a/resources/templates/service-crud-impl.ftl
+++ b/resources/templates/service-crud-impl.ftl
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.UUID;
 </#if>
 
+import java.util.Optional;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,4 +52,28 @@ public class ${clazz.name}ServiceCrudImpl implements I${clazz.name}ServiceCrud {
     public List<${clazz.name}> findAll() {
         return repository.findAll();
     }
+
+<#list clazz.properties as p>
+<#if p.searchable && !p.relation && !p.embedded>
+    @Override
+    @Transactional(readOnly = true)
+<#if p.unique>
+    public Optional<${clazz.name}> findBy${p.name?cap_first}(${typeUtil.toJava(p.type)} ${p.name}) {
+    return repository.findBy${p.name?cap_first}(${p.name});
+    }
+<#else>
+    public List<${clazz.name}> findBy${p.name?cap_first}(${typeUtil.toJava(p.type)} ${p.name}) {
+    return repository.findBy${p.name?cap_first}(${p.name});
+    }
+</#if>
+</#if>
+
+<#if p.rangeQuery && !p.relation && !p.embedded>
+    @Override
+    @Transactional(readOnly = true)
+    public List<${clazz.name}> findBy${p.name?cap_first}Between(${typeUtil.toJava(p.type)} start, ${typeUtil.toJava(p.type)} end) {
+    return repository.findBy${p.name?cap_first}Between(start, end);
+    }
+</#if>
+</#list>
 }

--- a/resources/templates/service-crud.ftl
+++ b/resources/templates/service-crud.ftl
@@ -5,6 +5,10 @@ import java.util.List;
 import java.util.UUID;
 </#if>
 
+import java.util.Optional;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import ${entityFqn};
 
 public interface I${clazz.name}ServiceCrud {
@@ -18,4 +22,18 @@ public interface I${clazz.name}ServiceCrud {
     ${clazz.name} findById(${idType} id);
 
     List<${clazz.name}> findAll();
+
+<#list clazz.properties as p>
+<#if p.searchable && !p.relation && !p.embedded>
+<#if p.unique>
+    Optional<${clazz.name}> findBy${p.name?cap_first}(${typeUtil.toJava(p.type)} ${p.name});
+<#else>
+    List<${clazz.name}> findBy${p.name?cap_first}(${typeUtil.toJava(p.type)} ${p.name});
+</#if>
+</#if>
+
+<#if p.rangeQuery && !p.relation && !p.embedded>
+    List<${clazz.name}> findBy${p.name?cap_first}Between(${typeUtil.toJava(p.type)} start, ${typeUtil.toJava(p.type)} end);
+</#if>
+</#list>
 }

--- a/src/myplugin/analyzer/ModelAnalyzer.java
+++ b/src/myplugin/analyzer/ModelAnalyzer.java
@@ -105,6 +105,7 @@ public class ModelAnalyzer {
 		}
 
 		addPropertiesFromClassMembers(cl, fmClass);
+		applyClassRepositoryQuery(cl, fmClass);
 		return fmClass;
 	}
 
@@ -157,6 +158,7 @@ public class ModelAnalyzer {
 		fp.setCollection(isCollection);
 		fp.setEnumeration(isEnum);
 		applyTaggedValueConstraints(p, fp);
+		applyRepositoryQueryTaggedValues(p, fp);
 		return fp;
 	}
 
@@ -380,6 +382,27 @@ public class ModelAnalyzer {
 				}
 			}
 		}
+	}
+
+	private void applyRepositoryQueryTaggedValues(Property source, FMProperty target) {
+		Stereotype stereo = StereotypesHelper.getAppliedStereotypeByString(source, "RepositoryQuery");
+		if (stereo == null) return;
+
+		target.setSearchable(getBooleanValue(source, stereo, "searchable", true));
+		target.setRangeQuery(getBooleanValue(source, stereo, "range", false));
+	}
+
+	private void applyClassRepositoryQuery(Class cl, FMClass fmClass) {
+		Stereotype stereo = StereotypesHelper.getAppliedStereotypeByString(cl, "RepositoryQuery");
+		if (stereo == null) return;
+
+		fmClass.setPagination(getBooleanValue(cl, stereo, "pagination", false));
+	}
+
+	private Boolean getBooleanValue(Element element, Stereotype stereo, String tag, boolean defaultValue) {
+		List<?> values = StereotypesHelper.getStereotypePropertyValue(element, stereo, tag);
+		if (values == null || values.isEmpty()) return defaultValue;
+		return (Boolean) values.get(0);
 	}
 
 	private void markAsManyToOne(FMProperty opposite, FMClass owner) {

--- a/src/myplugin/analyzer/ModelAnalyzer.java
+++ b/src/myplugin/analyzer/ModelAnalyzer.java
@@ -98,6 +98,12 @@ public class ModelAnalyzer {
 		}
 
 		FMClass fmClass = new FMClass(cl.getName());
+
+		Stereotype embeddableStereo = StereotypesHelper.getAppliedStereotypeByString(cl, "Embeddable");
+		if (embeddableStereo != null) {
+			fmClass.setEmbeddable(true);
+		}
+
 		addPropertiesFromClassMembers(cl, fmClass);
 		return fmClass;
 	}
@@ -273,6 +279,13 @@ public class ModelAnalyzer {
 					continue; // not a relation to another class in the model
 				}
 
+				if (target.isEmbeddable()) {
+					p.setEmbedded(true);
+					p.setRelation(false);
+					p.setTargetClass(target.getName());
+					continue;
+				}
+
 				p.setRelation(true);
 				p.setTargetClass(target.getName());
 
@@ -388,5 +401,14 @@ public class ModelAnalyzer {
 			}
 		}
 		return null;
+	}
+
+	private void classifyElementType(Class cl, FMClass fmClass) {
+		Stereotype embeddableStereo = StereotypesHelper.getAppliedStereotypeByString(cl, "Embeddable");
+		if (embeddableStereo != null) {
+			fmClass.setEmbeddable(true);
+			return;
+		}
+		fmClass.setEmbeddable(false);
 	}
 }

--- a/src/myplugin/generator/BasicGenerator.java
+++ b/src/myplugin/generator/BasicGenerator.java
@@ -32,7 +32,7 @@ public abstract class BasicGenerator {
 		this.generatorOptions = generatorOptions;
 	}
 
-	public void generate() throws IOException {		
+	public void generate() throws IOException {
 		if (generatorOptions.getOutputPath() == null) {
 			throw new IOException("Output path is not defined!");
 		}	
@@ -61,7 +61,7 @@ public abstract class BasicGenerator {
 							"An error occurred during folder creation " + generatorOptions.getOutputPath());
 			}
 		} catch (IOException e) {
-			throw new IOException("Can't find template " + tName + ".", e);
+			throw new IOException("Template error [" + tName + "]: " + e.getMessage(), e);
 		}
 
 	}

--- a/src/myplugin/generator/ControllerGenerator.java
+++ b/src/myplugin/generator/ControllerGenerator.java
@@ -46,6 +46,7 @@ public class ControllerGenerator extends BasicGenerator {
             model.put("entityFqn", entityFqn);
             model.put("serviceFqn", serviceFqn);
             model.put("basePath", basePath);
+            model.put("typeUtil", new TypeUtil());
 
             try {
                 getTemplate().process(model, out);

--- a/src/myplugin/generator/ControllerGenerator.java
+++ b/src/myplugin/generator/ControllerGenerator.java
@@ -27,6 +27,7 @@ public class ControllerGenerator extends BasicGenerator {
         super.generate();
 
         for (FMClass clazz : FMModel.getInstance().getClasses()) {
+            if(clazz.isEmbeddable()) continue;
             Writer out = getWriter(clazz.getName() + "Controller", generatorOptions.getFilePackage());
             if (out == null) continue;
 

--- a/src/myplugin/generator/RepositoryGenerator.java
+++ b/src/myplugin/generator/RepositoryGenerator.java
@@ -23,6 +23,7 @@ public class RepositoryGenerator extends BasicGenerator {
         super.generate();
 
         for (FMClass clazz : FMModel.getInstance().getClasses()) {
+            if(clazz.isEmbeddable()) continue;
             Writer out = getWriter(clazz.getName() + "Repository", generatorOptions.getFilePackage());
             if (out == null) continue;
 

--- a/src/myplugin/generator/ServiceCrudGenerator.java
+++ b/src/myplugin/generator/ServiceCrudGenerator.java
@@ -36,6 +36,7 @@ public class ServiceCrudGenerator extends BasicGenerator {
         boolean generatingInterface = isInterfaceTemplate(generatorOptions.getTemplateName());
 
         for (FMClass clazz : FMModel.getInstance().getClasses()) {
+            if(clazz.isEmbeddable()) continue;
             String idType = clazz.resolveIdType(generatorOptions);
 
             String fileNamePart;

--- a/src/myplugin/generator/ServiceCrudGenerator.java
+++ b/src/myplugin/generator/ServiceCrudGenerator.java
@@ -63,7 +63,7 @@ public class ServiceCrudGenerator extends BasicGenerator {
             model.put("entityFqn", entityFqn);
             model.put("repoFqn", repoFqn);
             model.put("interfaceFqn", interfaceFqn);
-
+            model.put("typeUtil", new TypeUtil());
             try {
                 getTemplate().process(model, out);
             } catch (Exception e) {

--- a/src/myplugin/generator/fmmodel/FMClass.java
+++ b/src/myplugin/generator/fmmodel/FMClass.java
@@ -16,6 +16,7 @@ import java.util.List;
 public class FMClass {
 	private String name;
 	private List<FMProperty> properties = new ArrayList<>();
+	private boolean embeddable = false;
 
 	public FMClass(String name) {
 		this.name = name;

--- a/src/myplugin/generator/fmmodel/FMClass.java
+++ b/src/myplugin/generator/fmmodel/FMClass.java
@@ -17,6 +17,7 @@ public class FMClass {
 	private String name;
 	private List<FMProperty> properties = new ArrayList<>();
 	private boolean embeddable = false;
+	private boolean pagination = false;
 
 	public FMClass(String name) {
 		this.name = name;

--- a/src/myplugin/generator/fmmodel/FMModel.java
+++ b/src/myplugin/generator/fmmodel/FMModel.java
@@ -41,4 +41,13 @@ public class FMModel {
 		}
 		return false;
 	}
+
+	public FMClass findEmbeddable(String className) {
+		for (FMClass c : getClasses()) {
+			if (className.equals(c.getName()) && c.isEmbeddable()) {
+				return c;
+			}
+		}
+		return null;
+	}
 }

--- a/src/myplugin/generator/fmmodel/FMProperty.java
+++ b/src/myplugin/generator/fmmodel/FMProperty.java
@@ -22,12 +22,15 @@ public class FMProperty {
 	private String mappedBy;
 
 	// Optional tagged-value driven constraints
-	private Boolean nullable;
-	private Boolean unique;
+	private Boolean nullable = false;
+	private Boolean unique = false;
 	private Integer size;
 	private String minValue;
 	private String maxValue;
 
+	private boolean searchable = false;    // findBy{name}
+	private boolean rangeQuery = false;    // findBy{date}Between
+	private boolean pagination = false;    // Pageable
 // getters/setters
 
 	public FMProperty(String name, String type, boolean id) {

--- a/src/myplugin/generator/fmmodel/FMProperty.java
+++ b/src/myplugin/generator/fmmodel/FMProperty.java
@@ -15,6 +15,7 @@ public class FMProperty {
 	private boolean relation;
 	private boolean collection;
 	private boolean enumeration;
+	private boolean embedded = false;
 
 	private String targetClass;
 	private RelationKind relationKind;


### PR DESCRIPTION
This PR adds support for generating custom query methods in Repository and Service layers, based on a new <<RepositoryQuery>> stereotype applied to UML class attributes and classes in MagicDraw.

To use <<RepositoryQuery>> stereotype in your UML model:
- Create Stereotype named RepositoryQuery:
- Set metaclass to both Property and Class
- Add tagged values:
   searchable (Boolean) – apply on property
   range (Boolean) – apply on property
   pagination (Boolean) – apply on class

Apply on property to generate findBy methods:
- Right-click on attribute → Stereotype → Apply RepositoryQuery
- Set searchable=true for findBy{Name} method
- Set range=true for findBy{Name}Between method

If property already has unique=true, return type will be Optional<T>

Apply on class to generate paginated findAll:
- Right-click on class → Stereotype → Apply RepositoryQuery
- Set pagination=true
- Run generation – Code Generation > Generate

<img width="1041" height="313" alt="image" src="https://github.com/user-attachments/assets/87da4d68-abad-4fed-ac00-fec485b18d35" />

<img width="899" height="284" alt="image" src="https://github.com/user-attachments/assets/aa5914dc-c890-4e32-a459-f26d511d766a" />

<img width="891" height="439" alt="image" src="https://github.com/user-attachments/assets/5bfc495e-5653-494b-9f4f-b1503c078a7a" />

<img width="895" height="475" alt="image" src="https://github.com/user-attachments/assets/f9545224-68a8-4255-ba81-5d2c196388eb" />


Closes #3 